### PR TITLE
Return Recipe Instead of MongoRecipe in RA

### DIFF
--- a/db/data/recipes.ts
+++ b/db/data/recipes.ts
@@ -1,8 +1,8 @@
-import { MongoRecipe } from "../../src/types/recipe";
+import { Recipe } from "../../src/types/recipe";
 
-export const recipes: MongoRecipe[] =  [
+export const recipes: Recipe[] =  [
   {
-    _id: "5fa8a136a26e5309eeda546b",
+    id: "5fa8a136a26e5309eeda546b",
     title: "Family Recipe",
     author: "Your mom",
     published: "1776-07-04T12:00:00.000Z",
@@ -10,7 +10,7 @@ export const recipes: MongoRecipe[] =  [
     description: "A delectable recipe for a dish your mom always cooks."
   },
   {
-    _id: "5fa8a511460dae6b34c2dee7",
+    id: "5fa8a511460dae6b34c2dee7",
     title: "Popeye's Spicy Strips",
     author: "Popeye",
     published: "1972-06-12T12:00:00.000Z",
@@ -18,7 +18,7 @@ export const recipes: MongoRecipe[] =  [
     description: "How to cook the world's best spicy chicken strips."
   },
   {
-    _id: "5fb0754318c0a72e04331f96",
+    id: "5fb0754318c0a72e04331f96",
     title: "Steak Pizzaiola",
     author: "Marie Barone",
     published: "1925-11-24T12:00:00.000Z",
@@ -26,7 +26,7 @@ export const recipes: MongoRecipe[] =  [
     description: "Steak dish commonly served in Everybody Loves Raymond."
   },
   {
-    _id: "5fb07613579f6de7d881be56",
+    id: "5fb07613579f6de7d881be56",
     title: "Chicken Fettuccine Alfredo",
     author: "Food Network",
     published: "2018-04-27T12:00:00.000Z",
@@ -34,7 +34,7 @@ export const recipes: MongoRecipe[] =  [
     url: "https://www.foodnetwork.com/recipes/food-network-kitchen/chicken-fettuccine-alfredo-3364118"
   },
   {
-    _id: "5fb0770e7dad2283a7ffd335",
+    id: "5fb0770e7dad2283a7ffd335",
     title: "Butter Chicken",
     author: "Anonymous",
     published: "2018-08-12T12:00:00.000Z",
@@ -42,7 +42,7 @@ export const recipes: MongoRecipe[] =  [
     description: "Heaven in your mouth."
   },
   {
-    _id: "5fb0778fe809db7536b3b67d",
+    id: "5fb0778fe809db7536b3b67d",
     title: "Stuffed Bell Peppers",
     author: "Colleen Case",
     published: "2034-01-05T12:00:00.000Z",
@@ -50,7 +50,7 @@ export const recipes: MongoRecipe[] =  [
     description: "Baked red bell peppers stuffed with filling"
   },
   {
-    _id: "5fb0788ab03235a70e65c4c0",
+    id: "5fb0788ab03235a70e65c4c0",
     title: "Tacos",
     author: "Maria Reina",
     published: "2011-10-10T12:00:00.000Z",
@@ -58,7 +58,7 @@ export const recipes: MongoRecipe[] =  [
     description: "Tacos. 'Nuff said."
   },
   {
-    _id: "5fb079151ba2603ac52fb1a0",
+    id: "5fb079151ba2603ac52fb1a0",
     title: "Noodles",
     author: "Family Recipe",
     published: "1952-12-25T12:00:00.000Z",
@@ -67,7 +67,7 @@ export const recipes: MongoRecipe[] =  [
     description: "Homemade egg noodles."
   },
   {
-    _id: "5fb080ec80ca03cc9b8ffce6",
+    id: "5fb080ec80ca03cc9b8ffce6",
     title: "Cup o' Noodles",
     author: "Maruchan",
     published: "1999-03-01T12:00:00.000Z",
@@ -75,14 +75,14 @@ export const recipes: MongoRecipe[] =  [
     description: "Classic college meal."
   },
   {
-    _id: "5fb0810f2761a4d66c237ace",
+    id: "5fb0810f2761a4d66c237ace",
     title: "PB&J Sandwich",
     author: "Unknown",
     published: "0001-01-01T12:00:00.000Z",
     recipe: "Let's face it. You know how to make one of these."
   },
   {
-    _id: "5fb08173f228f41f39684348",
+    id: "5fb08173f228f41f39684348",
     title: "Chicken Noodle Soup",
     author: "Unknown",
     published: "0001-01-01T12:00:00.000Z",
@@ -90,14 +90,14 @@ export const recipes: MongoRecipe[] =  [
     description: "Classic sick food."
   },
   {
-    _id: "5fb08187cd229e1e143d2fdd",
+    id: "5fb08187cd229e1e143d2fdd",
     title: "Boiled Egg",
     author: "Unknown",
     published: "0001-01-01T12:00:00.000Z",
     recipe: "Place egg in boiling water. Boil for 15 minutes. Peel and serve."
   },
   {
-    _id: "5fb0819827bc7f05e213ad2a",
+    id: "5fb0819827bc7f05e213ad2a",
     title: "Whataburger",
     author: "Whataburger",
     published: "1950-08-08T12:00:00.000Z",
@@ -105,7 +105,7 @@ export const recipes: MongoRecipe[] =  [
     description: "Classic Texas drunk food."
   },
   {
-    _id: "5fb081ae0123d89b8d9d852f",
+    id: "5fb081ae0123d89b8d9d852f",
     title: "Meatloaf",
     author: "Unknown",
     published: "1929-10-29T12:00:00.000Z",
@@ -113,7 +113,7 @@ export const recipes: MongoRecipe[] =  [
     description: "Nasty crap."
   },
   {
-    _id: "5fb081beb98cfe9f81d9f9a5",
+    id: "5fb081beb98cfe9f81d9f9a5",
     title: "Margarita",
     author: "Unknown",
     published: "1836-03-02T12:00:00.000Z",

--- a/src/engines/formattingEngine.ts
+++ b/src/engines/formattingEngine.ts
@@ -1,3 +1,21 @@
+import { MongoRecipe, Recipe } from "../types/recipe";
+
 export function escapePattern (pattern: string): string {
     return pattern.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+}
+
+export function fromMongoRecipe (mongoRecipe: MongoRecipe): Recipe {
+    const { _id, ...rest } = mongoRecipe;
+    return {
+        id: _id,
+        ...rest
+    };
+}
+
+export function toMongoRecipe (recipe: Recipe): MongoRecipe {
+    const { id, ...rest } = recipe;
+    return {
+        _id: id,
+        ...rest
+    };
 }

--- a/src/resourceAccess/recipeRA.ts
+++ b/src/resourceAccess/recipeRA.ts
@@ -1,10 +1,11 @@
 // Modules
 import { Db, MongoClient, ObjectID } from 'mongodb';
 import config from '../config';
+import { fromMongoRecipe } from "../engines/formattingEngine";
 
 // Types and Interfaces
 import { integer } from "../types/integer";
-import { Recipe, SearchResult } from '../types/recipe';
+import { MongoRecipe, Recipe, SearchResult } from '../types/recipe';
 
 class RecipeRA {
     private db: Db;
@@ -12,9 +13,9 @@ class RecipeRA {
     public async load(id: string): Promise<Recipe> {
         const [ recipe ] = await this.db
             .collection('recipes')
-            .find<Recipe>({"_id": ObjectID.createFromHexString(id)})
+            .find<MongoRecipe>({"_id": ObjectID.createFromHexString(id)})
             .toArray();
-        return recipe;
+        return fromMongoRecipe(recipe);
     }
 
     public async search(pattern: string, page: integer): Promise<SearchResult> {
@@ -23,7 +24,7 @@ class RecipeRA {
         const rowsToSkip = config.documentsPerPage * (page - 1);
         const recipesCursor = await this.db
             .collection('recipes')
-            .find<Recipe>({
+            .find<MongoRecipe>({
                 "$or": [
                     {title: likePatternRegex},
                     {recipe: likePatternRegex},
@@ -36,7 +37,7 @@ class RecipeRA {
         ]);
         return {
             count,
-            recipes
+            recipes: recipes.map(fromMongoRecipe)
         };
     }
 

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -2,19 +2,19 @@ import axios from 'axios';
 import config from '../src/config';
 import { expect } from 'chai';
 import { recipes } from '../db/data/recipes';
-import { MongoRecipe, Recipe, SearchResult } from "../src/types/recipe";
+import { Recipe, SearchResult } from "../src/types/recipe";
 import { integer } from "../src/types/integer";
 
 const commonSearchTerm = 'a';
 const mothersId = '5fa8a136a26e5309eeda546b';
 const popeyesId = '5fa8a511460dae6b34c2dee7';
-const mothersRecipe = recipes.find(recipe => recipe._id === mothersId);
-const popeyesRecipe = recipes.find(recipe => recipe._id === popeyesId);
+const mothersRecipe = recipes.find(recipe => recipe.id === mothersId);
+const popeyesRecipe = recipes.find(recipe => recipe.id === popeyesId);
 
-const sortById = function(recipe1: MongoRecipe, recipe2: MongoRecipe): integer {
-    if(recipe1._id < recipe2._id)
+const sortById = function(recipe1: Recipe, recipe2: Recipe): integer {
+    if(recipe1.id < recipe2.id)
         return -1;
-    if(recipe1._id > recipe2._id)
+    if(recipe1.id > recipe2.id)
         return 1;
     return 0;
 }


### PR DESCRIPTION
These changes fix the issue where the RA was actually returning `MongoRecipe` objects instead of `Recipe` objects.

Closes #7.