### PR TITLE
Implement Login

### DIFF
--- a/@types/express.d.ts
+++ b/@types/express.d.ts
@@ -1,0 +1,10 @@
+// Interfaces
+import { User } from "../src/types/user";
+
+declare global {
+    namespace Express {
+        interface Request {
+            user?: User | any;
+        }
+    }
+}

--- a/db/data/users.ts
+++ b/db/data/users.ts
@@ -1,6 +1,6 @@
-import { User } from "../../src/types/user";
+import { UserWithHash } from "../../src/types/user";
 
-export const existingUser: User = {
+export const existingUser: UserWithHash = {
     id: '6003d6d60e0dfd01a73ee3c0',
     created: '2021-01-01T12:00:00.000Z',
     email: 'test@user.org',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "@types/bcrypt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-3.0.0.tgz",
-      "integrity": "sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ=="
+      "integrity": "sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ==",
+      "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.0",
@@ -72,6 +73,15 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/jsonwebtoken": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+      "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -107,6 +117,17 @@
       "dev": true,
       "requires": {
         "@types/express": "*"
+      }
+    },
+    "@types/passport-jwt": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-3.0.3.tgz",
+      "integrity": "sha512-RlOCXiTitE8kazj9jZc6/BfGCSqnv2w/eYPDm3+3iNsquHn7ratu7oIUskZx9ZtnwMdpvdpy+Z/QYClocH5NvQ==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
       }
     },
     "@types/passport-local": {
@@ -325,6 +346,11 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -555,6 +581,14 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -925,6 +959,49 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -933,6 +1010,41 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -1282,6 +1394,15 @@
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
+      }
+    },
+    "passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "requires": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
       }
     },
     "passport-local": {

--- a/package.json
+++ b/package.json
@@ -20,20 +20,22 @@
   },
   "homepage": "https://github.com/PieceMaker/recipe-api#readme",
   "dependencies": {
-    "@types/bcrypt": "^3.0.0",
     "bcrypt": "^5.0.0",
     "express": "^4.17.1",
     "mongodb": "^3.6.2",
     "passport": "^0.4.1",
+    "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0"
   },
   "devDependencies": {
+    "@types/bcrypt": "^3.0.0",
     "@types/chai": "^4.2.14",
     "@types/chance": "^1.1.0",
     "@types/express": "^4.17.8",
     "@types/mocha": "^8.0.3",
     "@types/mongodb": "^3.5.27",
     "@types/passport": "^1.0.4",
+    "@types/passport-jwt": "^3.0.3",
     "@types/passport-local": "^1.0.33",
     "axios": "^0.21.0",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "bcrypt": "^5.0.0",
     "express": "^4.17.1",
+    "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.2",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",

--- a/server.ts
+++ b/server.ts
@@ -13,6 +13,10 @@ import recipe from './src/routes/recipe';
 app.use('/auth', auth);
 app.use('/recipe', recipe);
 
+// Setup middleware
+import { setupStrategies } from "./src/middleware/passport";
+setupStrategies();
+
 ////////
 // GET
 ////////

--- a/src/api/engines/jwtEngine.ts
+++ b/src/api/engines/jwtEngine.ts
@@ -3,17 +3,26 @@ import jsonwebtoken from 'jsonwebtoken';
 import config from '../../config';
 
 // Interfaces
+import { JWTPayload } from "../../types/jwt";
 import { User } from "../../types/user";
 
-export function issueJWT(user: User): string {
-    const payload = {
-        user,
-        iat: Date.now()
-    };
+export function issueJWT(user: User): { token: string } {
     // TODO: Figure out why setting algorithm here breaks TS...
     // const options = {
     //     algorithm: "HS256",
     //     expiresIn: config.jwt.expiresIn
     // }
-    return jsonwebtoken.sign(payload, config.jwt.secret, { algorithm: 'HS256', expiresIn: config.jwt.expiresIn});
+    const token = jsonwebtoken.sign(
+        { user },
+        config.jwt.secret,
+        {
+            algorithm: 'HS256',
+            expiresIn: config.jwt.expiresIn
+        }
+    );
+    return { token };
+}
+
+export function isExpired(payload: JWTPayload) {
+    return Math.ceil(Date.now() / 1000) > payload.exp;
 }

--- a/src/api/engines/jwtEngine.ts
+++ b/src/api/engines/jwtEngine.ts
@@ -1,0 +1,19 @@
+// Modules
+import jsonwebtoken from 'jsonwebtoken';
+import config from '../../config';
+
+// Interfaces
+import { User } from "../../types/user";
+
+export function issueJWT(user: User): string {
+    const payload = {
+        user,
+        iat: Date.now()
+    };
+    // TODO: Figure out why setting algorithm here breaks TS...
+    // const options = {
+    //     algorithm: "HS256",
+    //     expiresIn: config.jwt.expiresIn
+    // }
+    return jsonwebtoken.sign(payload, config.jwt.secret, { algorithm: 'HS256', expiresIn: config.jwt.expiresIn});
+}

--- a/src/api/engines/passwordEngine.ts
+++ b/src/api/engines/passwordEngine.ts
@@ -1,4 +1,9 @@
 import bcrypt from 'bcrypt';
+import config from '../../config';
+
+export function hashPassword(password: string): Promise<string> {
+    return bcrypt.hash(password, config.saltRounds);
+}
 
 export function verifyPassword(password: string, passwordHash: string): Promise<boolean> {
     return bcrypt.compare(password, passwordHash);

--- a/src/api/engines/passwordEngine.ts
+++ b/src/api/engines/passwordEngine.ts
@@ -1,0 +1,5 @@
+import bcrypt from 'bcrypt';
+
+export function verifyPassword(password: string, passwordHash: string): Promise<boolean> {
+    return bcrypt.compare(password, passwordHash);
+}

--- a/src/api/managers/userManager.ts
+++ b/src/api/managers/userManager.ts
@@ -1,8 +1,14 @@
 // Resource Access
 import userRA from "../resourceAccess/userRA";
 
+// Engines
+import { fromMongoRecord } from "../engines/formattingEngine";
+
+// Errors
+import { UserNotFound } from "../../errors";
+
 // Interfaces
-import { NewUser } from "../../types/user";
+import { MongoUser, NewUser, UserWithHash } from "../../types/user";
 
 class UserManager {
     public checkEmail(email: string): Promise<boolean> {
@@ -11,6 +17,14 @@ class UserManager {
 
     public checkUsername(userName: string): Promise<boolean> {
         return userRA.checkUsernameExists(userName);
+    }
+
+    public async getUser(userName: string): Promise<UserWithHash> {
+        const mongoUser = await userRA.getUser(userName);
+        if(!mongoUser) {
+            throw new UserNotFound(userName);
+        }
+        return fromMongoRecord<MongoUser>(mongoUser);
     }
 
     public insert(user: NewUser): Promise<string> {

--- a/src/api/managers/userManager.ts
+++ b/src/api/managers/userManager.ts
@@ -3,6 +3,7 @@ import userRA from "../resourceAccess/userRA";
 
 // Engines
 import { fromMongoRecord } from "../engines/formattingEngine";
+import { hashPassword } from "../engines/passwordEngine";
 
 // Errors
 import { UserNotFound } from "../../errors";
@@ -27,8 +28,9 @@ class UserManager {
         return fromMongoRecord<MongoUser>(mongoUser);
     }
 
-    public insert(user: NewUser): Promise<string> {
-        return userRA.insert(user);
+    public async insert(user: NewUser): Promise<string> {
+        const passwordHash = await hashPassword(user.password);
+        return userRA.insert(user, passwordHash);
     }
 }
 

--- a/src/api/resourceAccess/userRA.ts
+++ b/src/api/resourceAccess/userRA.ts
@@ -1,16 +1,12 @@
-import bcrypt from 'bcrypt';
-import config from '../../config';
-
 // Managers
 import dbManager from "../data/dbManager";
 
 // Types and Interfaces
-import { BaseUser, MongoUser, NewUser } from "../../types/user";
+import { BaseUser, MongoUser } from "../../types/user";
 
 class UserRA {
-    public async insert(user: NewUser): Promise<string> {
+    public async insert(user: BaseUser, passwordHash: string): Promise<string> {
         await dbManager.initialized;
-        const passwordHash = await bcrypt.hash(user.password, config.saltRounds);
         const dbUser: BaseUser & { passwordHash: string } = {
             email: user.email,
             firstName: user.firstName,

--- a/src/api/resourceAccess/userRA.ts
+++ b/src/api/resourceAccess/userRA.ts
@@ -5,7 +5,7 @@ import config from '../../config';
 import dbManager from "../data/dbManager";
 
 // Types and Interfaces
-import { BaseUser, NewUser } from "../../types/user";
+import { BaseUser, MongoUser, NewUser } from "../../types/user";
 
 class UserRA {
     public async insert(user: NewUser): Promise<string> {
@@ -40,6 +40,13 @@ class UserRA {
             .find({ username })
             .count();
         return matchingRecordCount > 0;
+    }
+
+    public async getUser(username: string): Promise<MongoUser | null> {
+        await dbManager.initialized;
+        return dbManager.db
+            .collection('users')
+            .findOne<MongoUser>({ username });
     }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,5 +4,6 @@ export default {
         db: 'recipes'
     },
     documentsPerPage: 10,
+    jwtSecret: 'MyTemp0r4ryS3cret',
     saltRounds: 14
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,10 @@ export default {
         db: 'recipes'
     },
     documentsPerPage: 10,
-    jwtSecret: 'MyTemp0r4ryS3cret',
+    jwt: {
+        algorithm: 'HS256',
+        expiresIn: '1d',
+        secret: 'MyTemp0r4ryS3cret'
+    },
     saltRounds: 14
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -44,3 +44,20 @@ export class UsernameInUse extends Error {
         };
     }
 }
+
+export class UserNotFound extends Error {
+    public username: string;
+
+    constructor(username: string) {
+        super('User not found.');
+        this.username = username;
+    }
+
+    toJSON() {
+        return {
+            username: this.username,
+            message: this.message,
+            name: 'UserNotFound'
+        };
+    }
+}

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -1,0 +1,53 @@
+import config from '../config';
+import passport from 'passport';
+import { ExtractJwt, Strategy as JWTStrategy } from 'passport-jwt';
+import { Strategy as LocalStrategy } from 'passport-local';
+
+// Managers
+import userManager from '../api/managers/userManager';
+
+// Engines
+import { verifyPassword } from "../api/engines/passwordEngine";
+
+// Errors
+import { UserNotFound } from "../errors";
+
+function setupJWTStrategy() {
+    passport.use('jwt', new JWTStrategy({
+        jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+        secretOrKey: config.jwtSecret,
+        algorithms: [ 'RS256' ]
+    }, (jwtPayload, done) => {
+        if(Date.now() > jwtPayload.expires) {
+            return done('JWT Expired', false);
+        }
+        return done(null, jwtPayload);
+    }));
+}
+
+function setupLocalStrategy() {
+    passport.use('local', new LocalStrategy({
+        usernameField: 'username',
+        passwordField: 'password'
+    }, async (username, password, done) => {
+        try {
+            const { passwordHash, ...rest } = await userManager.getUser(username);
+            const passwordIsValid = await verifyPassword(password, passwordHash);
+            if(!passwordIsValid) {
+                return done('Incorrect Username / Password', false);
+            } else {
+                return done(null, { ...rest });
+            }
+        } catch(error) {
+            if(error instanceof UserNotFound) {
+                return done('Incorrect Username / Password', false);
+            }
+            return done(error, false);
+        }
+    }));
+}
+
+export function setupStrategies() {
+    setupLocalStrategy();
+    setupJWTStrategy();
+}

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -13,6 +13,7 @@ import { verifyPassword } from "../api/engines/passwordEngine";
 import { UserNotFound } from "../errors";
 
 // Interfaces
+import { JWTPayload } from "../types/jwt";
 import { User } from "../types/user";
 
 function setupJWTStrategy() {
@@ -20,11 +21,8 @@ function setupJWTStrategy() {
         jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
         secretOrKey: config.jwt.secret,
         algorithms: [ config.jwt.algorithm ]
-    }, (jwtPayload, done) => {
-        if(Date.now() > jwtPayload.expires) {
-            return done('JWT Expired', false);
-        }
-        return done(null, jwtPayload);
+    }, ({ user }: JWTPayload, done) => {
+        return done(null, user);
     }));
 }
 

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -12,11 +12,14 @@ import { verifyPassword } from "../api/engines/passwordEngine";
 // Errors
 import { UserNotFound } from "../errors";
 
+// Interfaces
+import { User } from "../types/user";
+
 function setupJWTStrategy() {
     passport.use('jwt', new JWTStrategy({
         jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-        secretOrKey: config.jwtSecret,
-        algorithms: [ 'RS256' ]
+        secretOrKey: config.jwt.secret,
+        algorithms: [ config.jwt.algorithm ]
     }, (jwtPayload, done) => {
         if(Date.now() > jwtPayload.expires) {
             return done('JWT Expired', false);
@@ -36,7 +39,8 @@ function setupLocalStrategy() {
             if(!passwordIsValid) {
                 return done(null, false);
             } else {
-                return done(null, { ...rest });
+                const user: User = { ...rest };
+                return done(null, user);
             }
         } catch(error) {
             if(error instanceof UserNotFound) {

--- a/src/middleware/passport.ts
+++ b/src/middleware/passport.ts
@@ -34,13 +34,13 @@ function setupLocalStrategy() {
             const { passwordHash, ...rest } = await userManager.getUser(username);
             const passwordIsValid = await verifyPassword(password, passwordHash);
             if(!passwordIsValid) {
-                return done('Incorrect Username / Password', false);
+                return done(null, false);
             } else {
                 return done(null, { ...rest });
             }
         } catch(error) {
             if(error instanceof UserNotFound) {
-                return done('Incorrect Username / Password', false);
+                return done(null, false);
             }
             return done(error, false);
         }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,5 +1,6 @@
 // Modules
 import express from 'express';
+import passport from "passport";
 import { EmailInUse, PasswordMismatch, UsernameInUse } from "../errors";
 
 // Managers
@@ -7,6 +8,7 @@ import userManager from "../api/managers/userManager";
 
 // Engines
 import { errorToJSON } from "../api/engines/formattingEngine";
+import { issueJWT } from "../api/engines/jwtEngine";
 
 // Interfaces
 import { NewUser } from "../types/user";
@@ -40,5 +42,17 @@ router.post('/register', async (req, res) => {
         }
     }
 });
+
+router.post(
+    '/login',
+    passport.authenticate('local', { session: false }),
+    (req, res) => {
+        if(req.user) {
+            res.status(200).send(issueJWT(req.user));
+        } else {
+            res.status(401).send('Invalid Username/Password');
+        }
+    }
+);
 
 export default router;

--- a/src/types/jwt.ts
+++ b/src/types/jwt.ts
@@ -1,0 +1,8 @@
+// Interfaces
+import { User } from "./user";
+
+export interface JWTPayload {
+    user: User,
+    iat: number,
+    exp: number
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -13,6 +13,9 @@ export interface NewUser extends BaseUser {
 export interface User extends BaseUser {
     id: string;
     created: Date | string;
+}
+
+export interface UserWithHash extends User {
     passwordHash: string;
 }
 

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -28,46 +28,50 @@ const deleteNewUser = async function(): Promise<DeleteWriteOpResultObject> {
         .deleteOne({ username: newUser.username });
 }
 
-describe('Register', function() {
+describe('Authorization', function() {
 
-    it('should throw a "PasswordMismatch" error when the passwords do not match', async function() {
-        const mismatchingPasswordUser = { ...newUser };
-        mismatchingPasswordUser.repeatPassword = mismatchingPasswordUser.password + 'd';
-        const { data, status } = await authRegister(mismatchingPasswordUser);
-        expect(status).to.equal(400);
-        expect(data).to.have.all.keys([ 'message', 'name' ]);
-        expect(data.name).to.equal('PasswordMismatch');
-    });
+    describe('Register', function () {
 
-    it('should throw an "EmailInUse" error when the email matches an existing one', async function() {
-        const matchingEmailUser = { ...newUser };
-        matchingEmailUser.email = existingUser.email;
-        const { data, status } = await authRegister(matchingEmailUser);
-        expect(status).to.equal(400);
-        expect(data).to.have.all.keys([ 'email', 'message', 'name' ]);
-        expect(data.name).to.equal('EmailInUse');
-        expect(data.email).to.equal(existingUser.email);
-    });
+        it('should throw a "PasswordMismatch" error when the passwords do not match', async function () {
+            const mismatchingPasswordUser = {...newUser};
+            mismatchingPasswordUser.repeatPassword = mismatchingPasswordUser.password + 'd';
+            const {data, status} = await authRegister(mismatchingPasswordUser);
+            expect(status).to.equal(400);
+            expect(data).to.have.all.keys(['message', 'name']);
+            expect(data.name).to.equal('PasswordMismatch');
+        });
 
-    it('should throw a "UsernameInUse" error when the username matches an existing one', async function() {
-        const matchingUsernameUser = { ...newUser };
-        matchingUsernameUser.username = existingUser.username;
-        const { data, status } = await authRegister(matchingUsernameUser);
-        expect(status).to.equal(400);
-        expect(data).to.have.all.keys([ 'message', 'name', 'username' ]);
-        expect(data.name).to.equal('UsernameInUse');
-        expect(data.username).to.equal(existingUser.username);
-    });
+        it('should throw an "EmailInUse" error when the email matches an existing one', async function () {
+            const matchingEmailUser = {...newUser};
+            matchingEmailUser.email = existingUser.email;
+            const {data, status} = await authRegister(matchingEmailUser);
+            expect(status).to.equal(400);
+            expect(data).to.have.all.keys(['email', 'message', 'name']);
+            expect(data.name).to.equal('EmailInUse');
+            expect(data.email).to.equal(existingUser.email);
+        });
 
-    it('should return the inserted user identifier when successfully registering', async function() {
-        const { data, status } = await authRegister(newUser);
-        expect(status).to.equal(200);
-        expect(data).to.have.all.keys([ 'userId' ]);
-        expect(data.userId).to.be.a('string');
-    });
+        it('should throw a "UsernameInUse" error when the username matches an existing one', async function () {
+            const matchingUsernameUser = {...newUser};
+            matchingUsernameUser.username = existingUser.username;
+            const {data, status} = await authRegister(matchingUsernameUser);
+            expect(status).to.equal(400);
+            expect(data).to.have.all.keys(['message', 'name', 'username']);
+            expect(data.name).to.equal('UsernameInUse');
+            expect(data.username).to.equal(existingUser.username);
+        });
 
-    after(async function() {
-        await deleteNewUser();
+        it('should return the inserted user identifier when successfully registering', async function () {
+            const {data, status} = await authRegister(newUser);
+            expect(status).to.equal(200);
+            expect(data).to.have.all.keys(['userId']);
+            expect(data.userId).to.be.a('string');
+        });
+
+        after(async function () {
+            await deleteNewUser();
+        });
+
     });
 
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,7 @@
   "include": [
     "@types/express.d.ts",
     "src/**/*",
-    "tests/**/*"
+    "tests/**/*",
+    "server.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+     "typeRoots": [ "./node_modules/@types", "./@types" ],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
@@ -65,5 +65,10 @@
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "include": [
+    "@types/express.d.ts",
+    "src/**/*",
+    "tests/**/*"
+  ]
 }


### PR DESCRIPTION
These changes add a `/auth/login` endpoint which uses a `passport-local` strategy to verify the credentials. If the credentials are valid, then it returns a JWT to be used on future authenticated requests.